### PR TITLE
Shellcheck

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,16 +7,16 @@ tw_lines=""  # Lines containing trailing whitespaces.
 # TODO (harupy): Check only changed files.
 for file in $(git ls-files | sed -e 's/^/.\//')
 do
-  lines=$(egrep -rnIH " +$" $file | cut -f-2 -d ":")
-  if [ ! -z "$lines" ]; then
-    tw_lines+=$([[ -z "$tw_lines" ]] && echo "$lines" || echo $'\n'"$lines")
+  lines=$(grep -E -rnIH " +$" "$file" | cut -f-2 -d ":")
+  if [ -n "$lines" ]; then
+    tw_lines+="$([[ -z "$tw_lines" ]] && echo "$lines" || echo $'\n'"$lines")"
   fi
 done
 
 exit_code=0
 
 # If tw_lines is not empty, change the exit code to 1 to fail the CI.
-if [ ! -z "$tw_lines" ]; then
+if [ -n "$tw_lines" ]; then
   echo -e "\n***** Lines containing trailing whitespace *****\n"
   echo -e "${tw_lines[@]}"
   echo -e "\nFailed.\n"


### PR DESCRIPTION
Just a couple of small fixes here. This is still affected by [SC2030][] and [SC2031][], but if you're not worried about subshells, it's fine.

[SC2030]: https://github.com/koalaman/shellcheck/wiki/SC2030

[SC2031]: https://github.com/koalaman/shellcheck/wiki/SC2031